### PR TITLE
Use in-session Gemini API keys without local storage

### DIFF
--- a/src/main/webapp/WEB-INF/views/ai-coach.jsp
+++ b/src/main/webapp/WEB-INF/views/ai-coach.jsp
@@ -38,10 +38,10 @@
                         <div class="form-text" id="gemini-api-key-status"></div>
                     </div>
                     <div class="d-flex gap-2">
-                        <button type="submit" class="btn btn-primary flex-fill">저장</button>
+                        <button type="submit" class="btn btn-primary flex-fill">적용</button>
                         <button type="button" class="btn btn-outline-secondary flex-fill" id="gemini-api-key-clear">삭제</button>
                     </div>
-                    <p class="form-text mt-2">입력한 키는 이 브라우저의 로컬 저장소에만 보관됩니다.</p>
+                    <p class="form-text mt-2">입력한 키는 이 페이지에서만 사용되며 새로고침하면 초기화됩니다.</p>
                 </form>
             </div>
             <div class="card p-3 mb-4">

--- a/src/main/webapp/WEB-INF/views/exercise.jsp
+++ b/src/main/webapp/WEB-INF/views/exercise.jsp
@@ -24,10 +24,10 @@
                         <div class="form-text" id="gemini-api-key-status"></div>
                     </div>
                     <div class="d-flex gap-2">
-                        <button type="submit" class="btn btn-primary flex-fill">저장</button>
+                        <button type="submit" class="btn btn-primary flex-fill">적용</button>
                         <button type="button" class="btn btn-outline-secondary flex-fill" id="gemini-api-key-clear">삭제</button>
                     </div>
-                    <p class="form-text mt-2">입력한 키는 이 브라우저의 로컬 저장소에만 보관됩니다.</p>
+                    <p class="form-text mt-2">입력한 키는 이 페이지에서만 사용되며 새로고침하면 초기화됩니다.</p>
                 </form>
             </div>
             <div class="card p-3 mb-4">

--- a/src/main/webapp/resources/js/ai-coach.js
+++ b/src/main/webapp/resources/js/ai-coach.js
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', () => {
             } catch (error) {
                 removeLoadingMessage(loadingMessage);
                 if (error.message === 'API_KEY_MISSING') {
-                    addMessage('Gemini API 키가 설정되지 않았습니다. 키를 저장한 뒤 다시 시도해 주세요.', 'ai');
+                    addMessage('Gemini API 키가 설정되지 않았습니다. 키를 입력한 뒤 다시 시도해 주세요.', 'ai');
                     updateUiByApiKey();
                 } else {
                     console.error('Error:', error);

--- a/src/main/webapp/resources/js/common.js
+++ b/src/main/webapp/resources/js/common.js
@@ -1,7 +1,7 @@
 const appConfig = window.appConfig || {};
 const appRoot = appConfig.contextPath || '';
 let cachedAuthStatus = null;
-const GEMINI_API_STORAGE_KEY = 'geminiApiKey';
+let geminiApiKey = '';
 
 async function apiFetch(path, options = {}) {
     const url = path.startsWith('http') ? path : `${appRoot}${path}`;
@@ -94,27 +94,14 @@ async function updateAuthButtons() {
 }
 
 function getGeminiApiKey() {
-    try {
-        return localStorage.getItem(GEMINI_API_STORAGE_KEY) || '';
-    } catch (error) {
-        console.error('Gemini API 키를 불러오는 중 오류가 발생했습니다:', error);
-        return '';
-    }
+    return geminiApiKey;
 }
 
 function setGeminiApiKey(key) {
-    try {
-        if (key) {
-            localStorage.setItem(GEMINI_API_STORAGE_KEY, key);
-        } else {
-            localStorage.removeItem(GEMINI_API_STORAGE_KEY);
-        }
-        document.dispatchEvent(new CustomEvent('geminiApiKeyChanged', {
-            detail: { hasKey: Boolean(key) }
-        }));
-    } catch (error) {
-        console.error('Gemini API 키를 저장하는 중 오류가 발생했습니다:', error);
-    }
+    geminiApiKey = (key || '').trim();
+    document.dispatchEvent(new CustomEvent('geminiApiKeyChanged', {
+        detail: { hasKey: Boolean(geminiApiKey) }
+    }));
 }
 
 function clearGeminiApiKey() {

--- a/src/main/webapp/resources/js/exercise.js
+++ b/src/main/webapp/resources/js/exercise.js
@@ -89,7 +89,7 @@ document.addEventListener('DOMContentLoaded', () => {
             }
 
             if (!hasApiKey()) {
-                alert('AI 기능을 사용하려면 Gemini API 키를 저장해 주세요.');
+                alert('AI 기능을 사용하려면 Gemini API 키를 입력해 주세요.');
                 updateUiByApiKey();
                 return;
             }

--- a/src/main/webapp/resources/js/gemini-api-key.js
+++ b/src/main/webapp/resources/js/gemini-api-key.js
@@ -17,34 +17,34 @@
             status.textContent = message;
         }
 
-        function refreshForm() {
-            const currentKey = window.appUtils.getGeminiApiKey();
-            if (input) {
-                input.value = currentKey;
-            }
-            if (currentKey) {
-                updateStatusMessage('Gemini API 키가 저장되었습니다. (브라우저 로컬에만 저장됩니다.)', 'success');
+        function applyCurrentKey() {
+            const newKey = (input?.value || '').trim();
+            window.appUtils.setGeminiApiKey(newKey);
+            if (newKey) {
+                updateStatusMessage('Gemini API 키가 적용되었습니다. (페이지를 새로고침하면 초기화됩니다.)', 'success');
             } else {
-                updateStatusMessage('Gemini API 키가 설정되지 않았습니다. 키를 입력하면 AI 기능을 사용할 수 있습니다.');
+                updateStatusMessage('Gemini API 키를 입력하면 AI 기능을 사용할 수 있습니다.');
             }
-            document.dispatchEvent(new CustomEvent('geminiApiKeyChanged', {
-                detail: { hasKey: Boolean(currentKey) }
-            }));
         }
 
         form.addEventListener('submit', (event) => {
             event.preventDefault();
-            const newKey = (input?.value || '').trim();
-            if (!newKey) {
-                updateStatusMessage('API 키를 입력해 주세요.', 'danger');
+            if (!input) {
                 return;
             }
-            window.appUtils.setGeminiApiKey(newKey);
-            if (input) {
-                input.value = newKey;
+            if (!input.value.trim()) {
+                updateStatusMessage('API 키를 입력해 주세요.', 'danger');
+                window.appUtils.clearGeminiApiKey();
+                return;
             }
-            updateStatusMessage('Gemini API 키가 저장되었습니다. (브라우저 로컬에만 저장됩니다.)', 'success');
+            applyCurrentKey();
         });
+
+        if (input) {
+            input.addEventListener('input', () => {
+                applyCurrentKey();
+            });
+        }
 
         if (clearBtn) {
             clearBtn.addEventListener('click', () => {
@@ -52,10 +52,10 @@
                 if (input) {
                     input.value = '';
                 }
-                updateStatusMessage('Gemini API 키가 삭제되었습니다.', 'warning');
+                updateStatusMessage('Gemini API 키가 초기화되었습니다.', 'warning');
             });
         }
 
-        refreshForm();
+        applyCurrentKey();
     });
 })();


### PR DESCRIPTION
## Summary
- keep the Gemini API key in memory for the current session instead of local storage and broadcast changes via existing events
- update the API key form to apply keys as the user types, adjust messaging, and clarify session-scoped behavior in the UI
- align AI coach and exercise flows with the new wording so users just enter a key before making requests

## Testing
- not run (front-end updates only)


------
https://chatgpt.com/codex/tasks/task_e_68da0c4bcf78832e98261bba71c77a1b