### PR TITLE
Improve Gemini API key handling

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,12 +53,7 @@ mvn clean package
 
 ### 3. Gemini API 키 설정
 
-AI 코치와 운동 기록 예측은 클라이언트 측에서 Google Generative AI(Gemini)를 호출합니다. 아래 파일의 `GEMINI_API_KEY` 값을 발급받은 키로 교체하세요.
-
-```
-src/main/webapp/resources/js/ai-coach.js
-src/main/webapp/resources/js/exercise.js
-```
+AI 코치와 운동 기록 예측은 클라이언트 측에서 Google Generative AI(Gemini)를 호출합니다. 각 페이지의 "Gemini API 키" 카드에 발급받은 키를 입력하면 현재 브라우저 탭 전역에서 자동으로 공유되며, 탭을 닫거나 키를 지우면 초기화됩니다.
 <br>
 
 ### 4. 서버 실행

--- a/src/main/webapp/WEB-INF/views/ai-coach.jsp
+++ b/src/main/webapp/WEB-INF/views/ai-coach.jsp
@@ -37,7 +37,7 @@
                         <input type="password" class="form-control" id="gemini-api-key-input" placeholder="예: AIza..." autocomplete="new-password">
                         <div class="form-text" id="gemini-api-key-status"></div>
                     </div>
-                    <p class="form-text mt-2">입력한 키는 자동으로 적용되며 이 페이지에서만 사용됩니다. 새로고침하면 초기화됩니다.</p>
+                    <p class="form-text mt-2">입력한 키는 이 브라우저 탭 전역에서 자동으로 사용되며, 탭을 닫거나 키를 지우면 초기화됩니다.</p>
                 </div>
             </div>
             <div class="card p-3 mb-4">

--- a/src/main/webapp/WEB-INF/views/exercise.jsp
+++ b/src/main/webapp/WEB-INF/views/exercise.jsp
@@ -23,7 +23,7 @@
                         <input type="password" class="form-control" id="gemini-api-key-input" placeholder="예: AIza..." autocomplete="new-password">
                         <div class="form-text" id="gemini-api-key-status"></div>
                     </div>
-                    <p class="form-text mt-2">입력한 키는 자동으로 적용되며 이 페이지에서만 사용됩니다. 새로고침하면 초기화됩니다.</p>
+                    <p class="form-text mt-2">입력한 키는 이 브라우저 탭 전역에서 자동으로 사용되며, 탭을 닫거나 키를 지우면 초기화됩니다.</p>
                 </div>
             </div>
             <div class="card p-3 mb-4">

--- a/src/main/webapp/resources/js/gemini-api-key.js
+++ b/src/main/webapp/resources/js/gemini-api-key.js
@@ -13,14 +13,18 @@
 
         let lastHasKey = Boolean(window.appUtils.getGeminiApiKey());
 
-        function updateStatus(hasKey, variant) {
+        function updateStatus(hasKey, variant, customMessage) {
             if (!status) {
                 return;
             }
             const resolvedVariant = variant || (hasKey ? 'success' : 'muted');
             status.className = `form-text text-${resolvedVariant}`;
+            if (customMessage) {
+                status.textContent = customMessage;
+                return;
+            }
             status.textContent = hasKey
-                ? '입력한 Gemini API 키가 자동으로 사용됩니다. (페이지를 새로고침하면 초기화됩니다.)'
+                ? '입력한 Gemini API 키가 저장되어 이 브라우저 탭에서 자동으로 사용됩니다.'
                 : 'Gemini API 키를 입력하면 AI 기능을 사용할 수 있습니다.';
         }
 
@@ -29,7 +33,10 @@
             if (trimmed) {
                 lastHasKey = true;
                 window.appUtils.setGeminiApiKey(trimmed);
-                updateStatus(true);
+                const isLikelyValid = trimmed.length >= 20;
+                updateStatus(true, isLikelyValid ? 'success' : 'warning', isLikelyValid
+                    ? undefined
+                    : '입력된 값이 Gemini API 키 형식과 다를 수 있습니다. 다시 확인해 주세요.');
             } else {
                 const hadKeyBefore = lastHasKey;
                 lastHasKey = false;


### PR DESCRIPTION
## Summary
- persist the Gemini API key in session storage so AI features can reliably reuse it and surface clearer status messaging
- update the AI coach and exercise views plus documentation to explain the new key sharing behaviour
- harden the exercise AI request flow to report Gemini API errors when responses fail

## Testing
- not run (frontend-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68da17114a80832e948bdbadbb618ee1