### PR TITLE
Update Gemini API integrations to use 2.5 flash endpoint

### DIFF
--- a/src/main/webapp/resources/js/ai-coach.js
+++ b/src/main/webapp/resources/js/ai-coach.js
@@ -17,7 +17,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const sendBtn = document.getElementById('send-btn');
         const quickQuestionBtns = document.querySelectorAll('.quick-question-btn');
 
-        const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+        const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=';
 
         marked.setOptions({
             breaks: true,
@@ -114,7 +114,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             let response;
             try {
-                response = await fetch(`${GEMINI_ENDPOINT}?key=${encodeURIComponent(apiKey)}`, {
+                response = await fetch(`${GEMINI_API_URL}${encodeURIComponent(apiKey)}`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/src/main/webapp/resources/js/exercise.js
+++ b/src/main/webapp/resources/js/exercise.js
@@ -20,7 +20,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const saveExerciseBtn = document.getElementById('save-exercise-btn');
         const totalWeeklyCaloriesEl = document.getElementById('total-weekly-calories');
 
-        const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.0-flash:generateContent';
+        const GEMINI_API_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent?key=';
 
         exerciseDateInput.valueAsDate = new Date();
         let chartInstance;
@@ -83,7 +83,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
             let response;
             try {
-                response = await fetch(`${GEMINI_ENDPOINT}?key=${encodeURIComponent(apiKey)}`, {
+                response = await fetch(`${GEMINI_API_URL}${encodeURIComponent(apiKey)}`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/src/main/webapp/resources/js/gemini-client.js
+++ b/src/main/webapp/resources/js/gemini-client.js
@@ -1,5 +1,5 @@
 (function (global) {
-    const DEFAULT_MODEL = 'gemini-2.0-flash';
+    const DEFAULT_MODEL = 'gemini-2.5-flash';
     const API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
 
     function resolveKeyProvider() {


### PR DESCRIPTION
## Summary
- update the exercise and AI coach pages to call the Gemini 2.5 Flash generateContent endpoint using the required ?key= pattern
- align the shared Gemini client default model with the new gemini-2.5-flash release

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da2b19bf2c832e9713fb14292ddd8d